### PR TITLE
Remove Barracuda

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -88,10 +88,6 @@
 			background: black;
 			color: white;
 		}
-		.company.barracuda {
-			background: #0075c9;
-			color: white;
-		}
 		.company.copy {
 			background: #f5821f;
 			color: white;
@@ -269,9 +265,6 @@
 	</div>
 	<div class="company avegant">
 		<a href="http://www.avegant.com/" target="_blank">Avegant</a>
-	</div>
-	<div class="company barracuda">
-		<a href="http://barracuda.com" target="_blank">Barracuda</a>
 	</div>
 	<div class="company copy">
 		<a href="http://copy.com" target="_blank">Copy</a>


### PR DESCRIPTION
Guys, Barracuda is not a startup, not based in Ann Arbor, and has no founders here. Copy is sort of a stretch too - should we list Expedia and Mobiata too?

Maybe we should create another section here for anchor employers, or companies that have a presence here through acquisition? My own bar for this is companies that are primarily based here AND have engineering here - e.g. not the "ABC" (Ann Arbor is the Bangalore of California) companies like Systems In Motion, TD Ameritrade, Workforce Software, etc.

More complicated are the companies that started here, but have progressively moved elsewhere (headquartering out of state) - HookLogic, SightMachine, etc. Avegant has nothing here anymore. Occipital is a similar example.